### PR TITLE
Specify encoding in orcid-publications.py

### DIFF
--- a/scripts/orcid-publications.py
+++ b/scripts/orcid-publications.py
@@ -156,5 +156,5 @@ mds = "\n".join(md)
 
 # This will only work if this is run as a script
 path_out = Path(__file__).parent.parent / "_static/publications.txt"
-path_out.write_text(mds)
+path_out.write_text(mds, encoding='utf-8')
 print(f"Finished updating ORCID entries at: {path_out}")


### PR DESCRIPTION
I regenerated your publications.txt file using your script, and the encoding of my output file was ANSI (I'm on a Windows-based computer FYI). Unfortunately, trying to include the ANSI file in the publications.md file resulted in an error due to a non-standard character (ö) in a co-authors name:

    CRITICAL: Directive "include": error reading file: C:\Users\...\_static\publications.txt
    'utf-8' codec can't decode byte 0xf6 in position 1966: invalid start byte. 

 In order for others who may copy the script to avoid encountering the same error, I propose specifying the encoding of the output file as UTF-8.


I discovered the difference in encoding by using https://www.diffchecker.com/text-compare/, which gave away the difference:
![image](https://user-images.githubusercontent.com/39184289/215777360-7b583051-05e9-43a0-abbd-afa4952bab1a.png)
